### PR TITLE
Remove depency from `ttf-mscorefonts-installer`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 
 RUN apt-get update && apt-get install -y curl sudo
 
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe multiverse" | sudo tee -a /etc/apt/sources.list
 RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
 RUN sudo apt-get update && sudo apt-get install -y postgresql
 RUN service postgresql start && \
@@ -15,7 +14,6 @@ RUN sudo apt-get update && sudo apt-get install -y redis-server
 RUN sudo apt-get update && sudo apt-get install -y rabbitmq-server
 RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 RUN sudo echo "deb http://download.onlyoffice.com/repo/debian squeeze main" | sudo tee /etc/apt/sources.list.d/onlyoffice.list
-RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
 RUN echo onlyoffice-documentserver-ie onlyoffice/db-pwd select onlyoffice | sudo debconf-set-selections
 RUN service postgresql start && \
     sudo apt-get update && sudo apt-get -y install onlyoffice-documentserver-ie

--- a/Dockerfile-Debian-8
+++ b/Dockerfile-Debian-8
@@ -4,7 +4,6 @@ MAINTAINER Pavel.Lobashov "shockwavenn@gmail.com"
 
 RUN apt-get update && apt-get install -y curl sudo
 
-RUN echo "deb http://archive.ubuntu.com/ubuntu precise main universe multiverse" | sudo tee -a /etc/apt/sources.list
 RUN curl -sL https://deb.nodesource.com/setup_6.x | sudo bash -
 RUN sudo apt-get update && sudo apt-get install -y postgresql
 RUN service postgresql start && \
@@ -15,7 +14,6 @@ RUN sudo apt-get update && sudo apt-get install -y redis-server
 RUN sudo apt-get update && sudo apt-get install -y rabbitmq-server
 RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 RUN sudo echo "deb http://download.onlyoffice.com/repo/debian squeeze main" | sudo tee /etc/apt/sources.list.d/onlyoffice.list
-RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
 RUN echo onlyoffice-documentserver-ie onlyoffice/db-pwd select onlyoffice | sudo debconf-set-selections
 RUN service postgresql start && \
     sudo apt-get update && sudo apt-get -y --force-yes install onlyoffice-documentserver-ie

--- a/Dockerfile-Debian-9
+++ b/Dockerfile-Debian-9
@@ -15,7 +15,6 @@ RUN sudo apt-get update && sudo apt-get install -y redis-server
 RUN sudo apt-get update && sudo apt-get install -y rabbitmq-server
 RUN sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys CB2DE8E5
 RUN sudo echo "deb http://download.onlyoffice.com/repo/debian squeeze main" | sudo tee /etc/apt/sources.list.d/onlyoffice.list
-RUN echo ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true | sudo debconf-set-selections
 RUN echo onlyoffice-documentserver-ie onlyoffice/db-pwd select onlyoffice | sudo debconf-set-selections
 RUN service postgresql start && \
     sudo apt-get update && sudo apt-get -y --force-yes install onlyoffice-documentserver-ie


### PR DESCRIPTION
This dependency was remove from 5.1.0
See:
https://github.com/ONLYOFFICE/helpcenter/commit/b3bd48fc605aa16eec211ff41726a7a9fc396acb