### PR TITLE
Use supervisor command to start all services

### DIFF
--- a/Debian-8/Dockerfile
+++ b/Debian-8/Dockerfile
@@ -22,5 +22,5 @@ CMD service postgresql start && \
     service redis-server start && \
     service nginx start && \
     service supervisor start && \
-    supervisorctl start onlyoffice-documentserver:example && \
+    supervisorctl start all && \
     bash

--- a/Debian-9/Dockerfile
+++ b/Debian-9/Dockerfile
@@ -22,5 +22,5 @@ CMD service postgresql start && \
     service redis-server start && \
     service nginx start && \
     service supervisor start && \
-    supervisorctl start onlyoffice-documentserver:example && \
+    supervisorctl start all && \
     bash

--- a/Ubuntu-16.04/Dockerfile
+++ b/Ubuntu-16.04/Dockerfile
@@ -22,5 +22,5 @@ CMD service postgresql start && \
     service redis-server start && \
     service nginx start && \
     service supervisor start && \
-    supervisorctl start onlyoffice-documentserver:example && \
+    supervisorctl start all && \
     bash

--- a/Ubuntu-18.04/Dockerfile
+++ b/Ubuntu-18.04/Dockerfile
@@ -26,5 +26,5 @@ CMD service postgresql start && \
     service redis-server start && \
     service nginx start && \
     service supervisor start && \
-    supervisorctl start onlyoffice-documentserver:example && \
+    supervisorctl start all && \
     bash


### PR DESCRIPTION
1. Since DocumentServer 5.3.0 service change name to `ds:example`
2. If install OpenSource there is no such service at all

This fix both situations