### PR TITLE
Add fonts installation step for DocumentServer Centos

### DIFF
--- a/Centos7/install.sh
+++ b/Centos7/install.sh
@@ -32,6 +32,10 @@ sudo yum install rabbitmq-server -y
 sudo service rabbitmq-server start
 sudo systemctl enable rabbitmq-server
 
+sudo yum install cabextract xorg-x11-font-utils fontconfig
+sudo rpm -i https://deac-ams.dl.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm
+
+
 if [ "$#" -ne 1 ]; then
     sudo yum -y install http://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm
     sudo yum install ${DS_PRODUCT} -y

--- a/Centos7/install.sh
+++ b/Centos7/install.sh
@@ -35,7 +35,6 @@ sudo systemctl enable rabbitmq-server
 sudo yum install cabextract xorg-x11-font-utils fontconfig
 sudo rpm -i https://deac-ams.dl.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm
 
-
 if [ "$#" -ne 1 ]; then
     sudo yum -y install http://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm
     sudo yum install ${DS_PRODUCT} -y


### PR DESCRIPTION
This is already mentioned at here:
https://helpcenter.onlyoffice.com/installation/docs-community-install-centos.aspx

And it is required for DS v7.1.0 since https://github.com/ONLYOFFICE/document-server-package/commit/1f960dedfc1e06958ba56a24ff4947d62085fbc6