### PR TITLE
Add debian contrib as repo

### DIFF
--- a/Debian-10/Dockerfile
+++ b/Debian-10/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="shockwavenn@gmail.com"
 
 ENV DS_PRODUCT=onlyoffice-documentserver
 RUN apt-get update && apt-get install -y curl sudo gnupg
+RUN sed -r -i 's/^deb(.*)$/deb\1 contrib/g' /etc/apt/sources.list
 
 RUN sudo apt-get update && sudo apt-get install -y postgresql
 RUN service postgresql start && \

--- a/Debian-11/Dockerfile
+++ b/Debian-11/Dockerfile
@@ -2,7 +2,7 @@ FROM debian:bullseye
 
 LABEL maintainer="shockwavenn@gmail.com"
 
-ENV DS_PRODUCT=onlyoffice-documentserver-ee
+ENV DS_PRODUCT=onlyoffice-documentserver
 RUN apt-get update && apt-get install -y curl sudo gnupg
 RUN sed -r -i 's/^deb(.*)$/deb\1 contrib/g' /etc/apt/sources.list
 

--- a/Debian-11/Dockerfile
+++ b/Debian-11/Dockerfile
@@ -2,8 +2,9 @@ FROM debian:bullseye
 
 LABEL maintainer="shockwavenn@gmail.com"
 
-ENV DS_PRODUCT=onlyoffice-documentserver
+ENV DS_PRODUCT=onlyoffice-documentserver-ee
 RUN apt-get update && apt-get install -y curl sudo gnupg
+RUN sed -r -i 's/^deb(.*)$/deb\1 contrib/g' /etc/apt/sources.list
 
 RUN sudo apt-get update && sudo apt-get install -y postgresql
 RUN service postgresql start && \

--- a/Debian-8/Dockerfile
+++ b/Debian-8/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="shockwavenn@gmail.com"
 
 ENV DS_PRODUCT=onlyoffice-documentserver
 RUN apt-get update && apt-get install -y curl sudo
+RUN sed -r -i 's/^deb(.*)$/deb\1 contrib/g' /etc/apt/sources.list
 
 RUN sudo apt-get update && sudo apt-get install -y postgresql
 RUN service postgresql start && \

--- a/Debian-9/Dockerfile
+++ b/Debian-9/Dockerfile
@@ -4,6 +4,7 @@ LABEL maintainer="shockwavenn@gmail.com"
 
 ENV DS_PRODUCT=onlyoffice-documentserver
 RUN apt-get update && apt-get install -y curl sudo gnupg
+RUN sed -r -i 's/^deb(.*)$/deb\1 contrib/g' /etc/apt/sources.list
 
 RUN sudo apt-get update && sudo apt-get install -y postgresql
 RUN service postgresql start && \

--- a/Ubuntu-20.04/Dockerfile
+++ b/Ubuntu-20.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 LABEL maintainer="shockwavenn@gmail.com"
 ENV TZ=Etc/UTC
-ENV DS_PRODUCT=onlyoffice-documentserver-de
+ENV DS_PRODUCT=onlyoffice-documentserver
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update && apt-get install -y curl \ 

--- a/Ubuntu-20.04/Dockerfile
+++ b/Ubuntu-20.04/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:20.04
 
 LABEL maintainer="shockwavenn@gmail.com"
 ENV TZ=Etc/UTC
-ENV DS_PRODUCT=onlyoffice-documentserver
+ENV DS_PRODUCT=onlyoffice-documentserver-de
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 RUN apt-get update && apt-get install -y curl \ 


### PR DESCRIPTION
More details at Bug#57135

`ttf-mscorefonts-installer` is required since https://github.com/ONLYOFFICE/document-server-package/pull/271 in DocumentServer v7.1