### PR TITLE
Fix link for centos 7 `msttcore-fonts-installer-2.6-1.noarch`

### DIFF
--- a/Centos7/install.sh
+++ b/Centos7/install.sh
@@ -33,7 +33,7 @@ sudo service rabbitmq-server start
 sudo systemctl enable rabbitmq-server
 
 sudo yum -y install cabextract xorg-x11-font-utils fontconfig
-sudo rpm -i https://deac-ams.dl.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm
+sudo rpm -i https://rpmfind.net/linux/sourceforge/m/ms/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm
 
 if [ "$#" -ne 1 ]; then
     sudo yum -y install http://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm


### PR DESCRIPTION
Old link is not alive